### PR TITLE
Fix typo preventing `omnibus-ctl int <program>` from working

### DIFF
--- a/lib/omnibus-ctl.rb
+++ b/lib/omnibus-ctl.rb
@@ -27,7 +27,7 @@ module Omnibus
 
     File::umask(022)
 
-    SV_COMMAND_NAMES = %w[status up down once pause cont hup alarm interrupt quit
+    SV_COMMAND_NAMES = %w[status up down once pause cont hup alarm int quit
                       term kill start stop restart shutdown force-stop
                       force-reload force-restart force-shutdown check usr1 usr2]
 


### PR DESCRIPTION
Attempting to use the `int` command would result in this:

```
/opt/gitlab/embedded/lib/ruby/gems/2.3.0/gems/omnibus-ctl-0.5.0/lib/omnibus-ctl.rb:730:in `run': undefined method `int' for #<Omnibus::Ctl:0x0000000132dec0> (NoMethodError)
        from /opt/gitlab/embedded/lib/ruby/gems/2.3.0/gems/omnibus-ctl-0.5.0/bin/omnibus-ctl:31:in `<top (required)>'
        from /opt/gitlab/embedded/bin/omnibus-ctl:22:in `load'
        from /opt/gitlab/embedded/bin/omnibus-ctl:22:in `<main>'
```